### PR TITLE
Update getRelationshipBetweenInstances to resolve with a list

### DIFF
--- a/src/ggrc/assets/javascripts/components/people_list.js
+++ b/src/ggrc/assets/javascripts/components/people_list.js
@@ -378,17 +378,19 @@
 
         CMS.Models.Relationship
           .getRelationshipBetweenInstances(person, instance)
-          .done(function (relationship) {
+          .done(function (relationships) {
             var found = false;
-            if (_.exists(relationship, 'attrs.AssigneeType')) {
-              found = true;
-              relationship.refresh().then(function (relationship) {
-                var roles = relationship.attrs.AssigneeType.split(',');
-                var result = {roles: roles,
-                  relationship: relationship};
-                rolesDfd.resolve(result);
-              });
-            }
+            _.map(relationships, function (relationship) {
+              if (!found && _.exists(relationship, 'attrs.AssigneeType')) {
+                found = true;
+                relationship.refresh().then(function (relationship) {
+                  var roles = relationship.attrs.AssigneeType.split(',');
+                  var result = {roles: roles,
+                    relationship: relationship};
+                  rolesDfd.resolve(result);
+                });
+              }
+            });
             if (!found) {
               rolesDfd.resolve({roles: []});
             }

--- a/src/ggrc/assets/javascripts/models/mappers/tree-page-loader.js
+++ b/src/ggrc/assets/javascripts/models/mappers/tree-page-loader.js
@@ -3,7 +3,7 @@
  Licensed under http://www.apache.org/licenses/LICENSE-2.0 <see LICENSE file>
  */
 
-;(function (GGRC, can) {
+(function (GGRC, can) {
   'use strict';
 
   GGRC.ListLoaders.BaseListLoader('GGRC.ListLoaders.TreePageLoader', {}, {
@@ -41,18 +41,19 @@
     makeResult: function (instance, binding) {
       return CMS.Models.Relationship
         .getRelationshipBetweenInstances(binding.instance, instance)
-        .then(function (relationship) {
-          return new GGRC.ListLoaders.MappingResult(instance, [
-            {
-              binding: binding,
-              instance: relationship,
-              mappings: [{
-                instance: true,
-                mappings: [],
-                binding: binding
-              }]
-            }
-          ], binding);
+        .then(function (relationships) {
+          return new GGRC.ListLoaders.MappingResult(
+            instance, can.map(relationships, function (relationship) {
+              return {
+                binding: binding,
+                instance: relationship,
+                mappings: [{
+                  instance: true,
+                  mappings: [],
+                  binding: binding
+                }]
+              };
+            }), binding);
         });
     }
   });

--- a/src/ggrc/assets/javascripts/models/tests/join_models_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/join_models_spec.js
@@ -15,6 +15,7 @@ describe('CMS.Models.Relationship getRelationshipBetweenInstances() method',
         .and.callFake(function (id) {
           return {id: id};
         });
+      spyOn(console, 'warn');
     });
 
     it('return intersecting Relationships', function (done) {
@@ -124,6 +125,7 @@ describe('CMS.Models.Relationship getRelationshipBetweenInstances() method',
 
       result.then(function (res) {
         expect(res.length).toEqual(2);
+        expect(console.warn.calls.count()).toEqual(1);
         done();
       });
     });

--- a/src/ggrc/assets/javascripts/models/tests/join_models_spec.js
+++ b/src/ggrc/assets/javascripts/models/tests/join_models_spec.js
@@ -17,7 +17,7 @@ describe('CMS.Models.Relationship getRelationshipBetweenInstances() method',
         });
     });
 
-    it('return intersecting Relationship', function (done) {
+    it('return intersecting Relationships', function (done) {
       var result;
       instance1 = {
         related_sources: [{id: 1}, {id: 2}, {id: 3}],
@@ -31,7 +31,7 @@ describe('CMS.Models.Relationship getRelationshipBetweenInstances() method',
       result = method(instance1, instance2);
 
       result.then(function (res) {
-        expect(res).toEqual({id: 4});
+        expect(res[0]).toEqual({id: 4});
         done();
       });
     });
@@ -57,7 +57,7 @@ describe('CMS.Models.Relationship getRelationshipBetweenInstances() method',
       result = method(instance1, instance2);
 
       result.then(function (res) {
-        expect(res).toBeUndefined();
+        expect(res).toEqual([]);
         done();
       });
     });
@@ -77,7 +77,7 @@ describe('CMS.Models.Relationship getRelationshipBetweenInstances() method',
         result = method(instance1, instance2, true);
 
         result.then(function (res) {
-          expect(res).toBeUndefined();
+          expect(res).toEqual([]);
           done();
         });
       });
@@ -104,12 +104,12 @@ describe('CMS.Models.Relationship getRelationshipBetweenInstances() method',
       result = method(instance1, instance2);
 
       result.then(function (res) {
-        expect(res).toEqual({id: 4});
+        expect(res[0]).toEqual({id: 4});
         done();
       });
     });
 
-    it('returns more relevant RS for multiple intersection', function (done) {
+    it('returns all RS for multiple intersection', function (done) {
       var result;
       instance1 = {
         related_sources: [{id: 1}, {id: 2}, {id: 3}],
@@ -123,7 +123,7 @@ describe('CMS.Models.Relationship getRelationshipBetweenInstances() method',
       result = method(instance1, instance2);
 
       result.then(function (res) {
-        expect(res).toEqual({id: 5});
+        expect(res.length).toEqual(2);
         done();
       });
     });


### PR DESCRIPTION
We have 16 duplicated relationship rows in the grc-dev database with the last one created two weeks ago (2016-09-08 15:38:03) and 677 such rows on grc-test with the last one from the date 2016-07-13 13:49:01.

We won't be able to make sure this does not happen in prod for the quince release so we'll have to handle these duplicates in a better way.

`getRelationshipBetweenInstances` now resolves with a list of
relationships and the following two changes were applied:
- In TreePageLoader MappingResult now includes all relationships
- get_roles in people_list.js now looks for roles in all relationships
